### PR TITLE
[INFRA2-8685]migrate-gorush-to-helm3

### DIFF
--- a/chart/gorush/Chart.yaml
+++ b/chart/gorush/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-appVersion: "latest"
-description: A Helm chart for Kubernetes gorush
+apiVersion: v2
 name: gorush
+description: A Helm chart for Kubernetes gorush
+type: application
 version: 1.0.0
+appVersion: "latest"
 sources:
   - https://github.com/EENCloud/gorush
 maintainers:

--- a/chart/gorush/templates/NOTES.txt
+++ b/chart/gorush/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Get the application URL by running these commands:
 export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "gorush.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-echo "Visit http://127.0.0.1:8080 to use your application"
-kubectl port-forward $POD_NAME 8080:80
+echo "Visit http://127.0.0.1:8088 to use your application"
+kubectl port-forward $POD_NAME 8088:8088

--- a/chart/gorush/templates/service.yaml
+++ b/chart/gorush/templates/service.yaml
@@ -11,9 +11,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.port }}
+      targetPort: {{ .Values.ports.containerPort }}
       protocol: {{ .Values.service.protocol }}
-      name: {{ .Release.Name }}
+      name: http
   selector:
     app: {{ template "gorush.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Chart.yaml → apiVersion: v2 + type: application
Service targetPort now points at the container’s port (.Values.ports.containerPort) instead of the Service’s own port.
NOTES.txt port-forward corrected to 8088:8088 and message updated, so users actually reach the gorush process.
Service selector adds release: {{ .Release.Name }} to align with the Deployment’s labels, ensuring the Service selects the right Pods.