### PR TITLE
CODEOWNERS: owning team Events - OBC (263)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: Events - OBC (263).
+* @EENCloud/events-obc-263


### PR DESCRIPTION
Ensures **gorush** has a CODEOWNERS file naming its owning team **Events - OBC (263)** (`@EENCloud/events-obc-263`).

**Changes:** create .github/CODEOWNERS (@EENCloud/events-obc-263)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
